### PR TITLE
Retain read access to repo content in permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ jobs:
     # Permission overwrite is required for Dependabot PRs, see "Common issues" below.
     permissions:
       pull-requests: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -67,6 +68,7 @@ jobs:
     #####
     permissions:
       pull-requests: write
+      contents: read
     #####
     steps: ...
 ```


### PR DESCRIPTION
If you set `permissions`, it overrides all the usual permissions that
the GITHUB_TOKEN being used would have had - see the
[Automatic Token Authentication][1] documentation - by default
`contents` gets `read`, but if you set `permissions` you clobber all the
defaults:

> When the permissions key is used, all unspecified permissions are set
> to no access, with the exception of the metadata scope, which always
> gets read access.

So, the example in the README inadvertently clobbered the default `read`
permission for `contents`, meaning that the action couldn't be used on
private repositories.

[1]: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
